### PR TITLE
Added feature to broadcast mints

### DIFF
--- a/contracts/ERC721Universal.sol
+++ b/contracts/ERC721Universal.sol
@@ -60,7 +60,7 @@ contract ERC721Universal is
     }
 
     /// @inheritdoc IERC721Broadcast
-    function broadcast(uint256 tokenId) external {
+    function broadcastMint(uint256 tokenId) external {
         if (wasEverTransferred(tokenId))
             revert ERC721UniversalAlreadyTransferred(tokenId);
         emit Transfer(address(0), initOwner(tokenId), tokenId);

--- a/contracts/ERC721Universal.sol
+++ b/contracts/ERC721Universal.sol
@@ -67,7 +67,7 @@ contract ERC721Universal is
     /// @inheritdoc IERC721Broadcast
     function broadcastSelfTransfer(uint256 tokenId) external {
         _broadcast(tokenId, initOwner(tokenId));
-    }   
+    }
 
     /// @inheritdoc IERC721Broadcast
     function wasEverTransferred(uint256 tokenId) public view returns (bool) {
@@ -177,10 +177,9 @@ contract ERC721Universal is
      * @param tokenId the id of the token to be broadcasted
      * @param from the 'from' address to be used in the Transfer event
      */
-     function _broadcast(uint256 tokenId, address from) private {
+    function _broadcast(uint256 tokenId, address from) private {
         if (wasEverTransferred(tokenId))
             revert ERC721UniversalAlreadyTransferred(tokenId);
         emit Transfer(from, initOwner(tokenId), tokenId);
-    }   
-
+    }
 }

--- a/contracts/ERC721Universal.sol
+++ b/contracts/ERC721Universal.sol
@@ -5,6 +5,7 @@ import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "./IERC721Universal.sol";
 import "./IERC721UpdatableBaseURI.sol";
+import "./IERC721Broadcast.sol";
 
 /**
  * @title Contract for Universal Minting and Evolution of ERC721 tokens
@@ -18,6 +19,7 @@ import "./IERC721UpdatableBaseURI.sol";
 contract ERC721Universal is
     IERC721Universal,
     IERC721UpdatableBaseURI,
+    IERC721Broadcast,
     ERC721,
     Ownable
 {
@@ -55,6 +57,18 @@ contract ERC721Universal is
         if (isBaseURILocked) revert BaseURIAlreadyLocked();
         isBaseURILocked = true;
         emit LockedBaseURI(_baseURIStorage);
+    }
+
+    /// @inheritdoc IERC721Broadcast
+    function broadcast(uint256 tokenId) external {
+        if (wasEverTransferred(tokenId))
+            revert ERC721UniversalAlreadyTransferred(tokenId);
+        emit Transfer(address(0), initOwner(tokenId), tokenId);
+    }
+
+    /// @inheritdoc IERC721Broadcast
+    function wasEverTransferred(uint256 tokenId) public view returns (bool) {
+        return (super._ownerOf(tokenId) != address(0)) || isBurned[tokenId];
     }
 
     /**

--- a/contracts/ERC721Universal.sol
+++ b/contracts/ERC721Universal.sol
@@ -61,10 +61,13 @@ contract ERC721Universal is
 
     /// @inheritdoc IERC721Broadcast
     function broadcastMint(uint256 tokenId) external {
-        if (wasEverTransferred(tokenId))
-            revert ERC721UniversalAlreadyTransferred(tokenId);
-        emit Transfer(address(0), initOwner(tokenId), tokenId);
+        _broadcast(tokenId, address(0));
     }
+
+    /// @inheritdoc IERC721Broadcast
+    function broadcastSelfTransfer(uint256 tokenId) external {
+        _broadcast(tokenId, initOwner(tokenId));
+    }   
 
     /// @inheritdoc IERC721Broadcast
     function wasEverTransferred(uint256 tokenId) public view returns (bool) {
@@ -165,4 +168,20 @@ contract ERC721Universal is
     function initOwner(uint256 tokenId) public pure returns (address) {
         return address(uint160(tokenId));
     }
+
+
+    /**
+     * @notice For tokens that have never been transferred, it just emits an
+     *  ERC721 Transfer event from the provided 'from' address to the owner of the asset
+     * @dev This function reverts if the token has ever been transferred,
+     *  at least once, including tokens that have been burned.
+     * @param tokenId the id of the token to be broadcasted
+     * @param from the 'from' address to be used in the Transfer event
+     */
+     function _broadcast(uint256 tokenId, address from) private {
+        if (wasEverTransferred(tokenId))
+            revert ERC721UniversalAlreadyTransferred(tokenId);
+        emit Transfer(from, initOwner(tokenId), tokenId);
+    }   
+
 }

--- a/contracts/ERC721Universal.sol
+++ b/contracts/ERC721Universal.sol
@@ -101,6 +101,7 @@ contract ERC721Universal is
         return
             interfaceId == type(IERC721UpdatableBaseURI).interfaceId ||
             interfaceId == type(IERC721Universal).interfaceId ||
+            interfaceId == type(IERC721Broadcast).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 

--- a/contracts/IERC721Broadcast.sol
+++ b/contracts/IERC721Broadcast.sol
@@ -19,11 +19,11 @@ interface IERC721Broadcast {
      *  to inform DApps that listen for mints.
      *  The method must not change the state in any other way.
      * @dev This function must revert if the token has ever been transferred,
-     *  at least once, since it that case, DApps are already aware of the current
+     *  at least once, since in that case, DApps are already aware of the current
      *  owner, and by extension, about the initial mint of the asset.
      *  Since burning involves transferring to the null address, the method must also
      *  revert if the token has been burned.
-     * @param tokenId the id of the token to be broadcasted
+     * @param tokenId the id of the token to be broadcast
      */
     function broadcastMint(uint256 tokenId) external;
 
@@ -34,11 +34,11 @@ interface IERC721Broadcast {
      *  and then checking the previous and new owners against the contract state.
      *  The method must not change the state in any other way.
      * @dev This function must revert if the token has ever been transferred,
-     *  at least once, since it that case, DApps are already aware of the current
+     *  at least once, since in that case, DApps are already aware of the current
      *  owner, and by extension, about the initial mint of the asset.
      *  Since burning involves transferring to the null address, the method must also
      *  revert if the token has been burned.
-     * @param tokenId the id of the token to be broadcasted
+     * @param tokenId the id of the token to be broadcast
      */
     function broadcastSelfTransfer(uint256 tokenId) external;
 
@@ -46,7 +46,7 @@ interface IERC721Broadcast {
      * @notice Returns true if the token has already been transferred at least once
      * @dev Since burning involves transferring to the null address,
      *  the method must return true if the token has been burned.
-     * @param tokenId the id of the token to be broadcasted
+     * @param tokenId the id of the token to be broadcast
      * @return true if the token was ever transferred
      */
     function wasEverTransferred(uint256 tokenId) external view returns (bool);

--- a/contracts/IERC721Broadcast.sol
+++ b/contracts/IERC721Broadcast.sol
@@ -27,6 +27,21 @@ interface IERC721Broadcast {
     function broadcastMint(uint256 tokenId) external;
 
     /**
+     * @notice For tokens that have never been transferred, it just emits an
+     *  ERC721 Transfer event from the owner address to itself,
+     *  to inform DApps that display minted assets by listening to Transfer events,
+     *  and then checking the previous and new owners against the contract state.
+     *  The method must not change the state in any other way.
+     * @dev This function must revert if the token has ever been transferred,
+     *  at least once, since it that case, DApps are already aware of the current
+     *  owner, and by extension, about the initial mint of the asset.
+     *  Since burning involves transferring to the null address, the method must also
+     *  revert if the token has been burned.
+     * @param tokenId the id of the token to be broadcasted
+     */
+    function broadcastSelfTransfer(uint256 tokenId) external;
+
+    /**
      * @notice Returns true if the token has already been transferred at least once
      * @dev Since burning involves transferring to the null address,
      *  the method must return true if the token has been burned.

--- a/contracts/IERC721Broadcast.sol
+++ b/contracts/IERC721Broadcast.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.20;
 
 /**
  * @title ERC-721 Non-Fungible Token Standard, optional broadcastMint extension
+ * @dev The ERC-165 identifier for this interface is 0x9430f0b8
  * @author Freeverse.io, www.freeverse.io
  */
 interface IERC721Broadcast {

--- a/contracts/IERC721Broadcast.sol
+++ b/contracts/IERC721Broadcast.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.20;
 
 /**
- * @title ERC-721 Non-Fungible Token Standard, optional broadcast extension
+ * @title ERC-721 Non-Fungible Token Standard, optional broadcastMint extension
  * @author Freeverse.io, www.freeverse.io
  */
 interface IERC721Broadcast {
@@ -24,7 +24,7 @@ interface IERC721Broadcast {
      *  revert if the token has been burned.
      * @param tokenId the id of the token to be broadcasted
      */
-    function broadcast(uint256 tokenId) external;
+    function broadcastMint(uint256 tokenId) external;
 
     /**
      * @notice Returns true if the token has already been transferred at least once

--- a/contracts/IERC721Broadcast.sol
+++ b/contracts/IERC721Broadcast.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title ERC-721 Non-Fungible Token Standard, optional broadcast extension
+ * @author Freeverse.io, www.freeverse.io
+ */
+interface IERC721Broadcast {
+    /**
+     * @dev Indicates an error related the fact that a token was already transferred at least once
+     * @param tokenId The id of the token
+     */
+    error ERC721UniversalAlreadyTransferred(uint256 tokenId);
+
+    /**
+     * @notice For tokens that have never been transferred, it just emits an
+     *  ERC721 Transfer event from the null address to the initial owner,
+     *  to inform DApps that listen for mints.
+     *  The method must not change the state in any other way.
+     * @dev This function must revert if the token has ever been transferred,
+     *  at least once, since it that case, DApps are already aware of the current
+     *  owner, and by extension, about the initial mint of the asset.
+     *  Since burning involves transferring to the null address, the method must also
+     *  revert if the token has been burned.
+     * @param tokenId the id of the token to be broadcasted
+     */
+    function broadcast(uint256 tokenId) external;
+
+    /**
+     * @notice Returns true if the token has already been transferred at least once
+     * @dev Since burning involves transferring to the null address,
+     *  the method must return true if the token has been burned.
+     * @param tokenId the id of the token to be broadcasted
+     * @return true if the token was ever transferred
+     */
+    function wasEverTransferred(uint256 tokenId) external view returns (bool);
+}

--- a/contracts/tests/InterfaceId.sol
+++ b/contracts/tests/InterfaceId.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import "../ERC721Universal.sol";
+import "../IERC721Broadcast.sol";
 
 /**
  * @title Test contract for the purpose of verifying the interfaces
@@ -22,6 +23,10 @@ contract InterfaceId {
 
     function getERC721UpdatableBaseURIId() public pure returns(bytes4) {
         return type(IERC721UpdatableBaseURI).interfaceId;
+    }
+
+    function getERC721BroadcastId() public pure returns(bytes4) {
+        return type(IERC721Broadcast).interfaceId;
     }
 
     function supportsERC165(address _contractAddress) external view returns (bool) {

--- a/scripts/broadcast.ts
+++ b/scripts/broadcast.ts
@@ -1,0 +1,27 @@
+import { ethers } from "hardhat";
+
+async function main() {
+  const contractAddress = "0x618B30809ccB6597aBfE0822dC36096837288F5";
+  const tokenId = "1526678896913600633777236021071795506115833578868";
+  
+  const accounts = await ethers.getSigners();
+  console.log("Broadcasting in contract:", contractAddress);
+  console.log("...from the account:", accounts[0].address);
+
+  const ContractFactory = await ethers.getContractFactory(
+    "ERC721Universal",
+  );
+
+  const instance = await ContractFactory.attach(contractAddress);
+  const tx = await instance.broadcastSelfTransfer(tokenId);
+
+  console.log('Done');
+  console.log(tx);
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/broadcast.ts
+++ b/scripts/broadcast.ts
@@ -1,22 +1,34 @@
 import { ethers } from "hardhat";
 
 async function main() {
-  const contractAddress = "0x618B30809ccB6597aBfE0822dC36096837288F5";
-  const tokenId = "1526678896913600633777236021071795506115833578868";
-  
+  const tokenName = "laos-kitties";
+  const tokenSymbol = "LAK";
+  const baseURI = "evochain1/collectionId/";
+
   const accounts = await ethers.getSigners();
-  console.log("Broadcasting in contract:", contractAddress);
-  console.log("...from the account:", accounts[0].address);
+  console.log("Deploying contracts with the account:", accounts[0].address);
 
   const ContractFactory = await ethers.getContractFactory(
     "ERC721Universal",
   );
 
-  const instance = await ContractFactory.attach(contractAddress);
-  const tx = await instance.broadcastSelfTransfer(tokenId);
+  const instance = await ContractFactory.deploy(
+    accounts[0].address,
+    tokenName,
+    tokenSymbol,
+    baseURI,
+  );
+  await instance.waitForDeployment();
 
+  const contractAddress = await instance.getAddress(); //"0x618B30809ccB6597aBfE0822dC36096837288F5";
+  const tokenId = "1526678896913600633777236021071795506115833578868";
+  
+  console.log("Broadcasting in contract:", contractAddress);
+  console.log("...from the account:", accounts[0].address);
+  console.log("...tokenId:", tokenId);
+
+  await instance.broadcastSelfTransfer(tokenId);
   console.log('Done');
-  console.log(tx);
 }
 
 // We recommend this pattern to be able to use async/await everywhere

--- a/test/ERC721Universal.ts
+++ b/test/ERC721Universal.ts
@@ -683,20 +683,20 @@ describe("ERC721Broadcast", function () {
     expect(await erc721.wasEverTransferred(tokenId)).to.equal(true);
   });
 
-  it("broadcast works on non-transferred asset, and emits expected event", async function () {
+  it("broadcastMint works on non-transferred asset, and emits expected event", async function () {
     const slot = "111";
     const tokenId = ethers.toBeHex(
       "0x" + slot + addr1.address.substring(2),
       32,
     );
     const nullAddress = ethers.toBeHex(0, 20);
-    // note that the broadcast is sent by an address that
-    await expect(erc721.connect(addr2).broadcast(tokenId))
+    // note that the broadcastMint is sent by an address that
+    await expect(erc721.connect(addr2).broadcastMint(tokenId))
       .to.emit(erc721, "Transfer")
       .withArgs(nullAddress, addr1.address, tokenId);
   });
 
-  it("broadcast reverts on transferred assets", async function () {
+  it("broadcastMint reverts on transferred assets", async function () {
     const slot = "111";
     const tokenId = ethers.toBeHex(
       "0x" + slot + addr1.address.substring(2),
@@ -707,12 +707,12 @@ describe("ERC721Broadcast", function () {
     )
       .to.emit(erc721, "Transfer")
       .withArgs(addr1.address, addr2.address, tokenId);
-    await expect(erc721.connect(addr2).broadcast(tokenId))
+    await expect(erc721.connect(addr2).broadcastMint(tokenId))
       .to.be.revertedWithCustomError(erc721, "ERC721UniversalAlreadyTransferred")
       .withArgs(tokenId);
   });  
 
-  it("broadcast reverts on burned assets", async function () {
+  it("broadcastMint reverts on burned assets", async function () {
     const slot = "111";
     const tokenId = ethers.toBeHex(
       "0x" + slot + addr1.address.substring(2),
@@ -724,7 +724,7 @@ describe("ERC721Broadcast", function () {
     )
       .to.emit(erc721, "Transfer")
       .withArgs(addr1.address, nullAddress, tokenId);
-    await expect(erc721.connect(addr2).broadcast(tokenId))
+    await expect(erc721.connect(addr2).broadcastMint(tokenId))
       .to.be.revertedWithCustomError(erc721, "ERC721UniversalAlreadyTransferred")
       .withArgs(tokenId);
   });

--- a/test/ERC721Universal.ts
+++ b/test/ERC721Universal.ts
@@ -602,3 +602,130 @@ describe("ERC721UpdatableBaseURI", function () {
       .withArgs();      
   });
 });
+
+describe("ERC721Broadcast", function () {
+  const defaultURI = "evochain1/collectionId/";
+
+  let addr1: HardhatEthersSigner;
+  let addr2: HardhatEthersSigner;
+
+  let erc721: ERC721Universal;
+
+  // Deploy the contract and prepare accounts
+  beforeEach(async function () {
+    [addr1, addr2] = await ethers.getSigners();
+
+    const ERC721UniversalFactory = await ethers.getContractFactory(
+      "ERC721Universal",
+    );
+    erc721 = await ERC721UniversalFactory.deploy(
+      addr1.address,
+      "laos-kitties",
+      "LAK",
+      defaultURI,
+    );
+    await erc721.waitForDeployment();
+  });
+
+  it("wasEverTransferred returns false on non-transferred assets", async function () {
+    const slot = "111";
+    const tokenId = ethers.toBeHex(
+      "0x" + slot + addr1.address.substring(2),
+      32,
+    );
+    expect(await erc721.wasEverTransferred(tokenId)).to.equal(false);
+  });
+
+  it("wasEverTransferred returns true on transferred assets", async function () {
+    const slot = "111";
+    const tokenId = ethers.toBeHex(
+      "0x" + slot + addr1.address.substring(2),
+      32,
+    );
+    await expect(
+      erc721.connect(addr1).transferFrom(addr1.address, addr2.address, tokenId),
+    )
+      .to.emit(erc721, "Transfer")
+      .withArgs(addr1.address, addr2.address, tokenId);
+    expect(await erc721.wasEverTransferred(tokenId)).to.equal(true);
+  });
+
+  it("wasEverTransferred returns true on burned assets", async function () {
+    const slot = "111";
+    const tokenId = ethers.toBeHex(
+      "0x" + slot + addr1.address.substring(2),
+      32,
+    );
+    const nullAddress = ethers.toBeHex(0, 20);
+    await expect(erc721.connect(addr1).burn(tokenId))
+      .to.emit(erc721, "Transfer")
+      .withArgs(addr1.address, nullAddress, tokenId);
+    expect(await erc721.wasEverTransferred(tokenId)).to.equal(true);
+  });
+
+  it("wasEverTransferred returns true on burned assets after having been transferred", async function () {
+    const slot = "111";
+    const tokenId = ethers.toBeHex(
+      "0x" + slot + addr1.address.substring(2),
+      32,
+    );
+    expect(await erc721.wasEverTransferred(tokenId)).to.equal(false);
+    await expect(
+      erc721.connect(addr1).transferFrom(addr1.address, addr2.address, tokenId),
+    )
+      .to.emit(erc721, "Transfer")
+      .withArgs(addr1.address, addr2.address, tokenId);
+    expect(await erc721.wasEverTransferred(tokenId)).to.equal(true);
+    const nullAddress = ethers.toBeHex(0, 20);
+    await expect(erc721.connect(addr2).burn(tokenId))
+      .to.emit(erc721, "Transfer")
+      .withArgs(addr2.address, nullAddress, tokenId);
+    expect(await erc721.wasEverTransferred(tokenId)).to.equal(true);
+  });
+
+  it("broadcast works on non-transferred asset, and emits expected event", async function () {
+    const slot = "111";
+    const tokenId = ethers.toBeHex(
+      "0x" + slot + addr1.address.substring(2),
+      32,
+    );
+    const nullAddress = ethers.toBeHex(0, 20);
+    // note that the broadcast is sent by an address that
+    await expect(erc721.connect(addr2).broadcast(tokenId))
+      .to.emit(erc721, "Transfer")
+      .withArgs(nullAddress, addr1.address, tokenId);
+  });
+
+  it("broadcast reverts on transferred assets", async function () {
+    const slot = "111";
+    const tokenId = ethers.toBeHex(
+      "0x" + slot + addr1.address.substring(2),
+      32,
+    );
+    await expect(
+      erc721.connect(addr1).transferFrom(addr1.address, addr2.address, tokenId),
+    )
+      .to.emit(erc721, "Transfer")
+      .withArgs(addr1.address, addr2.address, tokenId);
+    await expect(erc721.connect(addr2).broadcast(tokenId))
+      .to.be.revertedWithCustomError(erc721, "ERC721UniversalAlreadyTransferred")
+      .withArgs(tokenId);
+  });  
+
+  it("broadcast reverts on burned assets", async function () {
+    const slot = "111";
+    const tokenId = ethers.toBeHex(
+      "0x" + slot + addr1.address.substring(2),
+      32,
+    );
+    const nullAddress = ethers.toBeHex(0, 20);
+    await expect(
+      erc721.connect(addr1).burn(tokenId),
+    )
+      .to.emit(erc721, "Transfer")
+      .withArgs(addr1.address, nullAddress, tokenId);
+    await expect(erc721.connect(addr2).broadcast(tokenId))
+      .to.be.revertedWithCustomError(erc721, "ERC721UniversalAlreadyTransferred")
+      .withArgs(tokenId);
+  });
+});

--- a/test/ERC721Universal.ts
+++ b/test/ERC721Universal.ts
@@ -627,6 +627,20 @@ describe("ERC721Broadcast", function () {
     await erc721.waitForDeployment();
   });
 
+  it("Should support the standard ERC721Broadcast interface", async function () {
+    const InterfaceIdFactory = await ethers.getContractFactory(
+      "InterfaceId",
+    );
+    const interfaceId = await InterfaceIdFactory.deploy();
+    await interfaceId.waitForDeployment();
+
+    // Tests both via direct contract calls, as well the on-chain OpenZeppelin lib checker:
+    const specified721Id = "0x9430f0b8";
+    expect(await interfaceId.getERC721BroadcastId()).to.equal(specified721Id);
+    expect(await erc721.supportsInterface(specified721Id)).to.equal(true);
+    expect(await interfaceId.supportsInterface(await erc721.getAddress(), specified721Id)).to.equal(true);
+  });
+
   it("wasEverTransferred returns false on non-transferred assets", async function () {
     const slot = "111";
     const tokenId = ethers.toBeHex(


### PR DESCRIPTION
This is an optional method that allows assets that have never been traded to emit the minimal events required to appear in some DApps, like marketplaces, that read Transfer events in order to detect asset mints. 