### PR TITLE
Added methods to update prefix and suffix place around tokenId to build tokenURI

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Here are approximate gas costs for comparison (check the [tests](./test/ERC721Un
 * Any number of mints in DApps using any of the above patterns: 0 gas
 * Mint of 1 asset using the default [OpenZeppelin ERC721 Contracts](https://github.com/OpenZeppelin/openzeppelin-contracts): 140,683 gas
 * `broadcastMint` of 1 asset: 28,140 gas
-* `broadcastSelfTransfer` of 1 asset: 28,164 gas
+* `broadcastSelfTransfer` of 1 asset: 28,207 gas
 * `broadcastSelfTransferBatch` of 1000 assets: 7,016,723 = 7,016 per asset
 
 

--- a/contracts/ERC721Universal.sol
+++ b/contracts/ERC721Universal.sol
@@ -35,8 +35,14 @@ contract ERC721Universal is
     // this string is prepended to tokenId to form the tokenURI
     string private _baseURIStorage;
 
-    // the string used to insert tokenId when building a universal location
-    string private constant TOKENID_STR = "GeneralKey(";
+    // the strings to be placed before & after tokenId to build a tokenURI
+    string private TOKENID_PRE = "GeneralKey(";
+    string private TOKENID_POST = ")";
+
+    modifier baseURINotLocked {
+        if (isBaseURILocked) revert BaseURIAlreadyLocked();
+        _;
+    }
 
     constructor(
         address owner_,
@@ -49,17 +55,22 @@ contract ERC721Universal is
     }
 
     /// @inheritdoc IERC721UpdatableBaseURI
-    function updateBaseURI(string calldata newBaseURI) external onlyOwner {
-        if (isBaseURILocked) revert BaseURIAlreadyLocked();
+    function updateBaseURI(string calldata newBaseURI) external onlyOwner baseURINotLocked {
         _baseURIStorage = newBaseURI;
         emit UpdatedBaseURI(newBaseURI);
     }
 
     /// @inheritdoc IERC721UpdatableBaseURI
-    function lockBaseURI() external onlyOwner {
-        if (isBaseURILocked) revert BaseURIAlreadyLocked();
+    function lockBaseURI() external onlyOwner baseURINotLocked {
         isBaseURILocked = true;
         emit LockedBaseURI(_baseURIStorage);
+    }
+
+    /// @inheritdoc IERC721UpdatableBaseURI
+    function updateTokenIdAffixes(string calldata newPrefix, string calldata newSuffix) external onlyOwner baseURINotLocked {
+        TOKENID_PRE = newPrefix;
+        TOKENID_POST = newSuffix;
+        emit updatedTokenIdAffixes(newPrefix, newSuffix);
     }
 
     /// @inheritdoc IERC721Broadcast
@@ -175,9 +186,9 @@ contract ERC721Universal is
             bytes(__baseURI).length > 0
                 ? string.concat(
                     __baseURI,
-                    TOKENID_STR,
+                    TOKENID_PRE,
                     Strings.toString(tokenId),
-                    ")"
+                    TOKENID_POST
                 )
                 : "";
     }

--- a/contracts/ERC721Universal.sol
+++ b/contracts/ERC721Universal.sol
@@ -70,7 +70,7 @@ contract ERC721Universal is
     function updateTokenIdAffixes(string calldata newPrefix, string calldata newSuffix) external onlyOwner baseURINotLocked {
         TOKENID_PRE = newPrefix;
         TOKENID_POST = newSuffix;
-        emit updatedTokenIdAffixes(newPrefix, newSuffix);
+        emit UpdatedTokenIdAffixes(newPrefix, newSuffix);
     }
 
     /// @inheritdoc IERC721Broadcast

--- a/contracts/IERC721UpdatableBaseURI.sol
+++ b/contracts/IERC721UpdatableBaseURI.sol
@@ -4,7 +4,8 @@ pragma solidity ^0.8.20;
 /**
  * @title Interface for ERC721 contracts which use a baseURI string
  *  to generate the tokenURI programmatically. It provides essential
- *  functions for managing the baseURI string.
+ *  functions for managing the baseURI string, as well as the prefix and
+ *  suffix strings placed before & after the tokenId to build the tokenURI
  * @dev The ERC-165 identifier for this interface is 0x418fb255
  * @author Freeverse.io, www.freeverse.io
  */
@@ -27,7 +28,7 @@ interface IERC721UpdatableBaseURI {
     event LockedBaseURI(string baseURI);
 
     /**
-     * @notice Event emitted on update of TokenId prefix and suffix
+     * @notice Event emitted on update of tokenId prefix and suffix
      * @param newPrefix the new string to be placed before the tokenId
      * @param newSuffix the new string to be placed after the tokenId
       */

--- a/contracts/IERC721UpdatableBaseURI.sol
+++ b/contracts/IERC721UpdatableBaseURI.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.20;
  * @title Interface for ERC721 contracts which use a baseURI string
  *  to generate the tokenURI programmatically. It provides essential
  *  functions for managing the baseURI string.
- * @dev The ERC-165 identifier for this interface is 0xb8382a4b
+ * @dev The ERC-165 identifier for this interface is 0x418fb255
  * @author Freeverse.io, www.freeverse.io
  */
 interface IERC721UpdatableBaseURI {
@@ -27,21 +27,39 @@ interface IERC721UpdatableBaseURI {
     event LockedBaseURI(string baseURI);
 
     /**
-     * @notice Returns true if the baseURI is permanently locked
-     * @return true if the baseURI is permanently locked
-     */
-    function isBaseURILocked() external view returns (bool);
+     * @notice Event emitted on update of TokenId prefix and suffix
+     * @param newPrefix the new string to be placed before the tokenId
+     * @param newSuffix the new string to be placed after the tokenId
+      */
+    event updatedTokenIdAffixes(string newPrefix, string newSuffix);
 
     /**
      * @notice Updates the baseURI that is used to build the tokenURIs
-     * @dev Only the owner of the ERC721 must be authorized to call this method
+     * @dev Only the owner of the ERC721 must is authorized to call this method
+     * @dev This method reverts if the baseURI is locked
      * @param newBaseURI the baseURI to be used to build the tokenURIs
      */
     function updateBaseURI(string calldata newBaseURI) external;
 
     /**
      * @notice Prevents any further change of the baseURI, permanently, by any actor
-     * @dev Only the owner of the ERC721 must be authorized to call this method
+     * @dev Only the owner of the ERC721 must is authorized to call this method
+     * @dev This method reverts if the baseURI is locked
      */
     function lockBaseURI() external;
+
+    /**
+     * @notice Updates the prefix and suffix strings placed around the tokenId to build the tokenURI
+     * @dev Only the owner of the ERC721 must is authorized to call this method
+     * @dev This method reverts if the baseURI is locked
+     * @param newPrefix the new string to be placed before the tokenId
+     * @param newSuffix the new string to be placed after the tokenId
+     */
+    function updateTokenIdAffixes(string calldata newPrefix, string calldata newSuffix) external;
+
+    /**
+     * @notice Returns true if the baseURI is permanently locked
+     * @return true if the baseURI is permanently locked
+     */
+    function isBaseURILocked() external view returns (bool);
 }

--- a/contracts/IERC721UpdatableBaseURI.sol
+++ b/contracts/IERC721UpdatableBaseURI.sol
@@ -31,7 +31,7 @@ interface IERC721UpdatableBaseURI {
      * @param newPrefix the new string to be placed before the tokenId
      * @param newSuffix the new string to be placed after the tokenId
       */
-    event updatedTokenIdAffixes(string newPrefix, string newSuffix);
+    event UpdatedTokenIdAffixes(string newPrefix, string newSuffix);
 
     /**
      * @notice Updates the baseURI that is used to build the tokenURIs

--- a/test/ERC721Universal.ts
+++ b/test/ERC721Universal.ts
@@ -560,7 +560,7 @@ describe("ERC721UpdatableBaseURI", function () {
 
   it("updates to affixes emits expected event", async function () {
     await expect(await erc721.connect(addr1).updateTokenIdAffixes("newprefix", "newsuffix"))
-      .to.emit(erc721, "updatedTokenIdAffixes")
+      .to.emit(erc721, "UpdatedTokenIdAffixes")
       .withArgs("newprefix", "newsuffix");
   });
 });

--- a/test/ERC721Universal.ts
+++ b/test/ERC721Universal.ts
@@ -476,7 +476,7 @@ describe("ERC721UpdatableBaseURI", function () {
     await interfaceId.waitForDeployment();
 
     // Tests both via direct contract calls, as well the on-chain OpenZeppelin lib checker:
-    const specifiedId = "0xb8382a4b";
+    const specifiedId = "0x418fb255";
     expect(await interfaceId.getERC721UpdatableBaseURIId()).to.equal(specifiedId);
     expect(await erc721.supportsInterface(specifiedId)).to.equal(true);
     expect(await interfaceId.supportsInterface(await erc721.getAddress(), specifiedId)).to.equal(true);
@@ -668,7 +668,7 @@ describe("ERC721Broadcast", function () {
     // note that the broadcasts are sent by any address; in this example, the address is not the owner of the asset
     const tx = await erc721.connect(addr2).broadcastMint(tokenId);
     const receipt = await tx.wait();
-    expect(receipt?.gasUsed).to.equal(28140);
+    expect(receipt?.gasUsed).to.equal(28207);
   });
 
   it("broadcastMintBatch cost of gas is as expected", async function () {

--- a/test/ERC721Universal.ts
+++ b/test/ERC721Universal.ts
@@ -517,7 +517,19 @@ describe("ERC721UpdatableBaseURI", function () {
       .to.emit(erc721, "LockedBaseURI")
       .withArgs(defaultURI);
 
+    expect(await erc721.isBaseURILocked()).to.equal(true);
+
     await expect(erc721.connect(addr1).updateBaseURI("new/mate"))
+      .to.be.revertedWithCustomError(erc721, "BaseURIAlreadyLocked")
+      .withArgs();      
+  });
+
+  it("locking baseURI prevents further changes of affixes", async function () {
+    await expect(erc721.connect(addr1).lockBaseURI())
+      .to.emit(erc721, "LockedBaseURI")
+      .withArgs(defaultURI);
+
+    await expect(erc721.connect(addr1).updateTokenIdAffixes("newprefix", "newsuffix"))
       .to.be.revertedWithCustomError(erc721, "BaseURIAlreadyLocked")
       .withArgs();      
   });
@@ -530,6 +542,26 @@ describe("ERC721UpdatableBaseURI", function () {
     await expect(erc721.connect(addr1).lockBaseURI())
       .to.be.revertedWithCustomError(erc721, "BaseURIAlreadyLocked")
       .withArgs();      
+  });
+
+  it("onlyOwner can update affixes", async function () {
+    await expect(erc721.connect(addr2).updateTokenIdAffixes("newprefix", "newsuffix"))
+      .to.be.revertedWithCustomError(erc721, "OwnableUnauthorizedAccount")
+      .withArgs(addr2.address);
+  });
+
+  it("updates to affixes work", async function () {
+    expect(await erc721.baseURI()).to.equal(defaultURI);
+    expect(await erc721.tokenURI(1)).to.equal(defaultURI + "GeneralKey(1)");
+    await erc721.connect(addr1).updateTokenIdAffixes("newprefix", "newsuffix");
+    expect(await erc721.baseURI()).to.equal(defaultURI);
+    expect(await erc721.tokenURI(1)).to.equal(defaultURI + "newprefix1newsuffix");
+  });
+
+  it("updates to affixes emits expected event", async function () {
+    await expect(await erc721.connect(addr1).updateTokenIdAffixes("newprefix", "newsuffix"))
+      .to.emit(erc721, "updatedTokenIdAffixes")
+      .withArgs("newprefix", "newsuffix");
   });
 });
 


### PR DESCRIPTION
No change in API, just a couple of methods added, alongside the corresponding events.

The tokenURI is build by concatenating baseURI + prefix + tokenId + suffix

This PR enables the owner to change of prefix and suffix. This privilege is lost when the baseURI is locked.